### PR TITLE
load once

### DIFF
--- a/slowfast/utils/checkpoint.py
+++ b/slowfast/utils/checkpoint.py
@@ -207,7 +207,7 @@ def load_checkpoint(
                 assert any(
                     prefix in key for prefix in ["momentum", "lr", "model_iter"]
                 ), "{} can not be converted".format(key)
-            ms.load_state_dict(state_dict, strict=False)
+        ms.load_state_dict(state_dict, strict=False)
         epoch = 0
     else:
         # Load the checkpoint on CPU to avoid GPU mem spike.


### PR DESCRIPTION
# Why
I noticed that the model loads the parameter "state_dict" every single iteration even if "state_dict" is added another key-value in progress.
I believe this is not the bug or error at all, but this change makes the loading process faster.

Thank you for consideration.