### PR TITLE
Remove detectron2 dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
         "termcolor>=1.1",
         "simplejson",
         "matplotlib",
-        "detectron2",
     ],
     packages=find_packages(exclude=("configs", "tests")),
 )


### PR DESCRIPTION
Because it cannot be installed from pypi