### PR TITLE
fix: import could not be found

### DIFF
--- a/slowfast/datasets/utils.py
+++ b/slowfast/datasets/utils.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 import torch
 from fvcore.common.file_io import PathManager
 
-import slowfast.datasets.transform as transform
+from . import transform as transform
 
 import cv2
 


### PR DESCRIPTION
In `slowfast/datasets/utils.py` I changed the import statement from
`import slowfast.datasets.transform as transform` to `from . import transform as transform` to prevent the following bug: `AttributeError: module 'slowfast' has no attribute 'datasets'` (see tracelog below)

-------

how to reproduce: create a yaml config that runs inference using 
```
TEST:
  ENABLE: True
  DATASET: kinetics
  BATCH_SIZE: 1
  CHECKPOINT_FILE_PATH: /slowfast/models/I3D_8x8_R50.pkl
DATA:
  PATH_TO_DATA_DIR: /slowfast/data/custom_kinetics_dataset
```
and run `python slowfast/tools/run_net.py --cfg /slowfast/custom_cfg.yaml`
to get the error:
```
Traceback (most recent call last):
  File "/slowfast/tools_c/run_net.py", line 11, in <module>
    from test_net import test
  File "/slowfast/tools_c/test_net.py", line 12, in <module>
    import slowfast.utils.misc as misc
  File "/slowfast/slowfast/utils/misc.py", line 15, in <module>
    from slowfast.datasets.utils import pack_pathway_output
  File "/slowfast/slowfast/datasets/__init__.py", line 4, in <module>
    from .ava_dataset import Ava  # noqa
  File "/slowfast/slowfast/datasets/ava_dataset.py", line 11, in <module>
    from . import utils as utils
  File "/slowfast/slowfast/datasets/utils.py", line 11, in <module>
    import slowfast.datasets.transform as transform
AttributeError: module 'slowfast' has no attribute 'datasets'
```