### PR TITLE
fix: add sklearn to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "psutil",
         "matplotlib",
         "torchvision>=0.4.2",
+        "sklearn"
     ],
     packages=find_packages(exclude=("configs", "tests")),
 )


### PR DESCRIPTION
In the file `slowfast/utils/meters.py` we are importing `from sklearn.metrics import average_precision_score` which leads to a `ModuleNotFoundError: No module named 'sklearn'` if no sklearn (scikit-learn) package is installed.
We can fix this by installing sklearn using `pip install sklearn` or automatically on `python setup.py build develop` by adding sklearn to the requirements list.

--------------

How to reproduce: create a yaml config that runs inference using 
```
TEST:
  ENABLE: True
  DATASET: kinetics
  BATCH_SIZE: 1
  CHECKPOINT_FILE_PATH: /slowfast/models/I3D_8x8_R50.pkl
DATA:
  PATH_TO_DATA_DIR: /slowfast/data/custom_kinetics_dataset
```
and run `python slowfast/tools/run_net.py --cfg /slowfast/custom_cfg.yaml`
to get the error:
```
Traceback (most recent call last):
  File "/slowfast/tools/run_net.py", line 11, in <module>
    from test_net import test
  File "/slowfast/tools/test_net.py", line 15, in <module>
    from slowfast.utils.meters import AVAMeter, TestMeter
  File "/slowfast/slowfast/utils/meters.py", line 24, in <module>
    from sklearn.metrics import average_precision_score
ModuleNotFoundError: No module named 'sklearn'
```
Note: I used the fixed version from PR https://github.com/facebookresearch/SlowFast/pull/173 .