### PR TITLE
softmax dim should be 1 for ResNetRoIHead

### DIFF
--- a/slowfast/models/head_helper.py
+++ b/slowfast/models/head_helper.py
@@ -91,7 +91,7 @@ class ResNetRoIHead(nn.Module):
 
         # Softmax for evaluation and testing.
         if act_func == "softmax":
-            self.act = nn.Softmax(dim=4)
+            self.act = nn.Softmax(dim=1)
         elif act_func == "sigmoid":
             self.act = nn.Sigmoid()
         else:
@@ -183,7 +183,7 @@ class ResNetBasicHead(nn.Module):
 
         # Softmax for evaluation and testing.
         if act_func == "softmax":
-            self.act = nn.Softmax(dim=4)
+            self.act = nn.Softmax(dim=1)
         elif act_func == "sigmoid":
             self.act = nn.Sigmoid()
         else:

--- a/slowfast/models/head_helper.py
+++ b/slowfast/models/head_helper.py
@@ -183,7 +183,7 @@ class ResNetBasicHead(nn.Module):
 
         # Softmax for evaluation and testing.
         if act_func == "softmax":
-            self.act = nn.Softmax(dim=1)
+            self.act = nn.Softmax(dim=4)
         elif act_func == "sigmoid":
             self.act = nn.Sigmoid()
         else:


### PR DESCRIPTION
![Screenshot from 2020-05-26 16-25-31](https://user-images.githubusercontent.com/16210053/82892712-951a4580-9f6d-11ea-8dc4-9b83e1fa2a3a.png)

Issue: Softmax dimension out of range

steps to reproduce: 
1. In the configfile configs/AVA/c2/SLOWFAST_32x2_R50.yaml , change the MODEL.HEAD_ACT to softmax from sigmoid
2. Run the cmd - python3 tools/run_net.py   --cfg configs/AVA/c2/SLOWFAST_32x2_R50.yaml   DATA.PATH_TO_DATA_DIR /home/appuser/proc_dir/ava   NUM_GPUS 1 TRAIN.ENABLE True

Fix: It should be because of the dimension parameter given to nn.Softmax. Changed it to dim=1