### PR TITLE
fix logging bug

### DIFF
--- a/slowfast/utils/logging.py
+++ b/slowfast/utils/logging.py
@@ -42,9 +42,6 @@ def setup_logging(output_dir=None):
     if du.is_master_proc():
         # Enable logging for the master process.
         logging.root.handlers = []
-        logging.basicConfig(
-            level=logging.INFO, format=_FORMAT, stream=sys.stdout
-        )
     else:
         # Suppress logging for non-master processes.
         _suppress_print()


### PR DESCRIPTION
Summary:
the logger always prints the same message twice to console.
The sys.stdout handler was adder twice for the logger:
1. logging.basicConfig
2. ch = logging.StreamHandler(stream=sys.stdout)

Delete the first one.