### PR TITLE
Save preds and labels to the specified file

### DIFF
--- a/tools/test_net.py
+++ b/tools/test_net.py
@@ -126,7 +126,7 @@ def perform_test(test_loader, model, test_meter, cfg, writer=None):
             save_path = os.path.join(cfg.OUTPUT_DIR, cfg.TEST.SAVE_RESULTS_PATH)
 
             with PathManager.open(save_path, "wb") as f:
-                pickle.dump([all_labels, all_labels], f)
+                pickle.dump([all_preds, all_labels], f)
 
             logger.info(
                 "Successfully saved prediction results to {}".format(save_path)


### PR DESCRIPTION
This seems to be a minor bug.
I suppose the author was saving the labels and predicted labels respectively, not labels and labels.