### PR TITLE
Prediction logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea/
 .vscode/
 *.py[cod]
+
+configs/custom
+models

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+.vscode/
+*.py[cod]

--- a/slowfast/config/defaults.py
+++ b/slowfast/config/defaults.py
@@ -705,6 +705,9 @@ _C.DEMO.DETECTRON2_THRESH = 0.9
 # The number of overlapping frames cannot be larger than
 # half of the sequence length `cfg.DATA.NUM_FRAMES * cfg.DATA.SAMPLING_RATE`
 _C.DEMO.BUFFER_SIZE = 0
+# Display the output prediction onto the input video
+# If disabled, output predictions will be logged instead of displaying the video
+_C.DEMO.OUTPUT_DISPLAY = True
 # If specified, the visualized outputs will be written this a video file of
 # this path. Otherwise, the visualized outputs will be displayed in a window.
 _C.DEMO.OUTPUT_FILE = ""

--- a/slowfast/utils/logging.py
+++ b/slowfast/utils/logging.py
@@ -64,11 +64,16 @@ def setup_logging(output_dir=None):
         logger.addHandler(ch)
 
     if output_dir is not None and du.is_master_proc(du.get_world_size()):
-        filename = os.path.join(output_dir, "stdout.log")
-        fh = logging.StreamHandler(_cached_log_stream(filename))
-        fh.setLevel(logging.DEBUG)
-        fh.setFormatter(plain_formatter)
-        logger.addHandler(fh)
+        setup_file_logger(logger, output_dir, "stdout.log", plain_formatter)
+
+
+def setup_file_logger(logger, output_dir, file_name, formatter=None):
+    filename = os.path.join(output_dir, file_name)
+    fh = logging.StreamHandler(_cached_log_stream(filename))
+    fh.setLevel(logging.DEBUG)
+    fh.setFormatter(formatter or logging.Formatter("%(message)s"))
+    logger.addHandler(fh)
+    logger.setLevel(logging.DEBUG)
 
 
 def get_logger(name):

--- a/slowfast/visualization/async_predictor.py
+++ b/slowfast/visualization/async_predictor.py
@@ -315,7 +315,7 @@ def draw_predictions(task, video_vis):
                 boxes,
                 keyframe_idx=keyframe_idx,
                 draw_range=draw_range,
-                task=task,
+                task_id=task.id,
             )
     else:
         frames = video_vis.draw_clip_range(
@@ -323,7 +323,7 @@ def draw_predictions(task, video_vis):
             preds,
             keyframe_idx=keyframe_idx,
             draw_range=draw_range,
-            task=task,
+            task_id=task.id,
         )
     del task
 
@@ -366,7 +366,7 @@ def log_predictions(task, video_vis):
                 boxes,
                 keyframe_idx=keyframe_idx,
                 draw_range=draw_range,
-                task=task,
+                task_id=task.id,
             )
     else:
         frames = video_vis.draw_clip_range(
@@ -374,7 +374,7 @@ def log_predictions(task, video_vis):
             preds,
             keyframe_idx=keyframe_idx,
             draw_range=draw_range,
-            task=task,
+            task_id=task.id,
         )
     del task
 

--- a/slowfast/visualization/async_predictor.py
+++ b/slowfast/visualization/async_predictor.py
@@ -315,10 +315,15 @@ def draw_predictions(task, video_vis):
                 boxes,
                 keyframe_idx=keyframe_idx,
                 draw_range=draw_range,
+                task=task,
             )
     else:
         frames = video_vis.draw_clip_range(
-            frames, preds, keyframe_idx=keyframe_idx, draw_range=draw_range
+            frames,
+            preds,
+            keyframe_idx=keyframe_idx,
+            draw_range=draw_range,
+            task=task,
         )
     del task
 
@@ -361,10 +366,15 @@ def log_predictions(task, video_vis):
                 boxes,
                 keyframe_idx=keyframe_idx,
                 draw_range=draw_range,
+                task=task,
             )
     else:
         frames = video_vis.draw_clip_range(
-            frames, preds, keyframe_idx=keyframe_idx, draw_range=draw_range
+            frames,
+            preds,
+            keyframe_idx=keyframe_idx,
+            draw_range=draw_range,
+            task=task,
         )
     del task
 

--- a/slowfast/visualization/ava_demo_precomputed_boxes.py
+++ b/slowfast/visualization/ava_demo_precomputed_boxes.py
@@ -294,6 +294,7 @@ class AVAVisualizerWithPrecomputedBox:
                     ground_truth=ground_truth,
                     draw_range=current_draw_range,
                     repeat_frame=repeat,
+                    task=task,
                 )
             # Store the current clip as buffer.
             prev_buffer = clip

--- a/slowfast/visualization/ava_demo_precomputed_boxes.py
+++ b/slowfast/visualization/ava_demo_precomputed_boxes.py
@@ -294,7 +294,6 @@ class AVAVisualizerWithPrecomputedBox:
                     ground_truth=ground_truth,
                     draw_range=current_draw_range,
                     repeat_frame=repeat,
-                    task=task,
                 )
             # Store the current clip as buffer.
             prev_buffer = clip

--- a/slowfast/visualization/predictor.py
+++ b/slowfast/visualization/predictor.py
@@ -33,6 +33,8 @@ class Predictor:
             self.gpu_id = (
                 torch.cuda.current_device() if gpu_id is None else gpu_id
             )
+        else:
+            self.gpu_id = None
 
         # Build the video model and print model statistics.
         self.model = build_model(cfg, gpu_id=gpu_id)

--- a/slowfast/visualization/video_visualizer.py
+++ b/slowfast/visualization/video_visualizer.py
@@ -522,7 +522,7 @@ class VideoVisualizer:
         keyframe_idx=None,
         draw_range=None,
         repeat_frame=1,
-        task=None,
+        task_id=None,
     ):
         """
         Draw predicted labels or ground truth classes to clip. Draw bouding boxes to clip
@@ -539,6 +539,7 @@ class VideoVisualizer:
             draw_range (Optional[list[ints]): only draw frames in range [start_idx, end_idx] inclusively in the clip.
                 If None, draw on the entire clip.
             repeat_frame (int): repeat each frame in draw_range for `repeat_frame` time for slow-motion effect.
+            task_id (int): reference index of the task where frames and predictions originated from.
         """
         if draw_range is None:
             draw_range = [0, len(frames) - 1]
@@ -681,7 +682,9 @@ class VideoVisualizer:
 
 class VideoLogger(VideoVisualizer):
     """
-    Core is identical to visualizer. Override draw method to only log.
+    Log predictions to file instead of drawing onto output video frames.
+
+    Core is identical to `VideoVisualizer`. Override draw method to log.
     """
     def __init__(self, *_, **__):
         super(VideoLogger, self).__init__(*_, **__)
@@ -697,9 +700,9 @@ class VideoLogger(VideoVisualizer):
         keyframe_idx=None,
         draw_range=None,
         repeat_frame=1,
-        task=None,
+        task_id=None,
     ):
-        self.clip_index = task.id if task else self.clip_index + 1
+        self.clip_index = task_id or self.clip_index + 1
         num_frames = len(frames)
         start_frame = self.clip_index * num_frames
         frame_range = [start_frame, start_frame + num_frames - 1]


### PR DESCRIPTION
I would like to contribute some piece of code I added to provide logging capabilities of video predictions to file. 
This is useful to extract raw actions (class labels and confidence) over video segments.

The idea is simple. I override the `draw_clip_range` method of the demo visualizer to report predicted actions and bounding boxes to a `predictions.log` file instead of written onto output video frames. 

To preserve original behavior of the demo visualizer, I add a option `DEMO.OUTPUT_DISPLAY` that is by default running the original demo code (eg: display video in window or written to file). When set to `False`, the logging override is used instead. This will write what would otherwise be drawn on the frames into text form in the log file under `OUTPUT_DIR`.

The resulting log will be similar to the following : 
```
0000 [00000000, 00000063]:
    bbox: [490.73, 83.06, 664.0, 415.62], is predicted to class [0.96] stand, top-k=5: ['stand', 'listen to (a person)', 'watch (a person)', 'talk to (e.g., self, a person, a group)', 'carry/hold (an object)'], [0.9636, 0.5954, 0.5248, 0.3115, 0.2907]
    bbox: [152.0, 125.62, 306.25, 307.59], is predicted to class [0.32] talk to (e.g., self, a person, a group), top-k=5: ['talk to (e.g., self, a person, a group)', 'carry/hold (an object)', 'stand', 'watch (a person)', 'listen to (a person)'], [0.3207, 0.2872, 0.2723, 0.2469, 0.2244]
    bbox: [384.1, 90.81, 522.25, 281.81], is predicted to class [0.85] stand, top-k=5: ['stand', 'talk to (e.g., self, a person, a group)', 'listen to (a person)', 'carry/hold (an object)', 'watch (a person)'], [0.8543, 0.503, 0.503, 0.433, 0.3979]
0001 [00000000, 00000063]:
    bbox: [56.78, 62.19, 359.23, 418.54], is predicted to class [0.42] stand, top-k=5: ['stand', 'watch (a person)', 'sit', 'listen to (a person)', 'talk to (e.g., self, a person, a group)'], [0.4152, 0.3692, 0.3509, 0.2042, 0.1815]
    bbox: [300.56, 73.32, 658.27, 400.85], is predicted to class [0.72] stand, top-k=5: ['stand', 'watch (a person)', 'listen to (a person)', 'carry/hold (an object)', 'talk to (e.g., self, a person, a group)'], [0.7185, 0.4697, 0.4342, 0.4063, 0.2994]
0002 [00000064, 00000127]:
    bbox: [73.31, 63.27, 367.26, 430.84], is predicted to class [0.67] stand, top-k=5: ['stand', 'listen to (a person)', 'talk to (e.g., self, a person, a group)', 'sit', 'watch (a person)'], [0.6749, 0.3374, 0.2068, 0.2064, 0.1532]
    bbox: [325.06, 80.53, 645.83, 420.41], is predicted to class [0.77] sit, top-k=5: ['sit', 'talk to (e.g., self, a person, a group)', 'listen to (a person)', 'watch (a person)', 'stand'], [0.7728, 0.4179, 0.2485, 0.2396, 0.1557]
0003 [00000064, 00000127]:
    bbox: [299.5, 107.28, 712.75, 428.47], is predicted to class [0.55] stand, top-k=5: ['stand', 'watch (a person)', 'sit', 'walk', 'carry/hold (an object)'], [0.5498, 0.3916, 0.18, 0.154, 0.1356]
[...]
```
Each new sampled "clip section" is marked with `<clip/task-id> [<start-frame>, <end-frame>]`, and then provides the predicted actions for each detected bounding box. 

Above results where obtained using AVA checkpoint & classes, and Detectron2 predictor for bounding boxes. 
The `top-k` mode and `k=5` were used to generate these results, but outputs will adjust accordingly with `thres` mode or other values of `k`, in the same manner the original visualizer did.

