### PR TITLE
fix import int_class error for nightly pytorch

### DIFF
--- a/slowfast/datasets/multigrid_helper.py
+++ b/slowfast/datasets/multigrid_helper.py
@@ -4,7 +4,16 @@
 """Helper functions for multigrid training."""
 
 import numpy as np
+import torch
 from torch.utils.data.sampler import Sampler
+
+TORCH_MAJOR = int(torch.__version__.split('.')[0])
+TORCH_MINOR = int(torch.__version__.split('.')[1])
+
+if TORCH_MAJOR >= 1 and TORCH_MINOR >= 8:
+    _int_classes = int
+else:
+    from torch._six import int_classes as _int_classes
 
 
 class ShortCycleBatchSampler(Sampler):
@@ -21,7 +30,7 @@ class ShortCycleBatchSampler(Sampler):
                 "torch.utils.data.Sampler, but got sampler={}".format(sampler)
             )
         if (
-            not isinstance(batch_size, int)
+            not isinstance(batch_size, _int_classes)
             or isinstance(batch_size, bool)
             or batch_size <= 0
         ):

--- a/slowfast/datasets/multigrid_helper.py
+++ b/slowfast/datasets/multigrid_helper.py
@@ -4,7 +4,6 @@
 """Helper functions for multigrid training."""
 
 import numpy as np
-from torch._six import int_classes as _int_classes
 from torch.utils.data.sampler import Sampler
 
 
@@ -22,7 +21,7 @@ class ShortCycleBatchSampler(Sampler):
                 "torch.utils.data.Sampler, but got sampler={}".format(sampler)
             )
         if (
-            not isinstance(batch_size, _int_classes)
+            not isinstance(batch_size, int)
             or isinstance(batch_size, bool)
             or batch_size <= 0
         ):


### PR DESCRIPTION
Nightly PyTorch has removed `int_class` from `torch._six` and directly
use `int` instead.
https://github.com/pytorch/pytorch/commit/58eb23378f2a376565a66ac32c93a316c45b6131#diff-ab54604ec520467537cb424daad0f56b2f5702e2f4d7fa2e9f68c9def296ccdfL10