### PR TITLE
requirement name changed form `PIL` to `Pillow`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "opencv-python",
         "pandas",
         "torchvision>=0.4.2",
-        "PIL",
+        "Pillow",
         "sklearn",
         "tensorboard",
     ],


### PR DESCRIPTION
Based on docs here: https://pillow.readthedocs.io/en/stable/installation.html