### PR TITLE
fix import torch._six error for pytorch 2.0

### DIFF
--- a/slowfast/datasets/multigrid_helper.py
+++ b/slowfast/datasets/multigrid_helper.py
@@ -10,7 +10,7 @@ from torch.utils.data.sampler import Sampler
 TORCH_MAJOR = int(torch.__version__.split(".")[0])
 TORCH_MINOR = int(torch.__version__.split(".")[1])
 
-if TORCH_MAJOR >= 1 and TORCH_MINOR >= 8:
+if (TORCH_MAJOR >= 1 and TORCH_MINOR >= 8) or TORCH_MAJOR >= 2:
     _int_classes = int
 else:
     from torch._six import int_classes as _int_classes


### PR DESCRIPTION
When running SlowFast on pytorch 2.0, an error encountered to me:
```bash
Traceback (most recent call last):
  File "/home/ubuntu/SlowFast/tools/run_net.py", line 10, in <module>
    from test_net import test
  File "/home/ubuntu/SlowFast/tools/test_net.py", line 16, in <module>
    from slowfast.datasets import loader
  File "/home/ubuntu/SlowFast/slowfast/datasets/loader.py", line 15, in <module>
    from slowfast.datasets.multigrid_helper import ShortCycleBatchSampler
  File "/home/ubuntu/SlowFast/slowfast/datasets/multigrid_helper.py", line 16, in <module>
    from torch._six import int_classes as _int_classes
ModuleNotFoundError: No module named 'torch._six'
```
Thus I provide this PR for compatibility with pytorch 2.0.
